### PR TITLE
Added validation of IPv6 addresses and supporting tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PREFIX := /etc/openvpn
+DESTDIR := $(PREFIX)/scripts
+
+SRC = update-systemd-resolved
+DEST = $(DESTDIR)/$(SRC)
+
+.PHONY: all install info
+
+all: install info
+
+install:
+	@install -Dm750 $(SRC) $(DEST)
+
+info:
+	@printf 'Successfully installed %s to %s.\n' $(SRC) $(DEST)
+	@echo
+	@echo 'Now would be a good time to update /etc/nsswitch.conf:'
+	@echo '  # Use systemd-resolved first, then fall back to /etc/resolv.conf'
+	@echo '  hosts: files resolve dns myhostname'
+	@echo '  # Use /etc/resolv.conf first, then fall back to systemd-resolved'
+	@echo '  hosts: files dns resolve myhostname'
+	@echo
+	@echo 'You should also update your OpenVPN configuration:'
+	@printf '  script-security 2\n  up %s\n  down %s\n' $(DEST) $(DEST)

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,7 @@ info:
 	@echo '  hosts: files dns resolve myhostname'
 	@echo
 	@echo 'You should also update your OpenVPN configuration:'
-	@printf '  script-security 2\n  up %s\n  down %s\n' $(DEST) $(DEST)
+	@printf '  script-security 2\n  up %s\n  pre-down %s\n' $(DEST) $(DEST)
+
+test:
+	@./run-tests

--- a/run-tests
+++ b/run-tests
@@ -26,6 +26,10 @@ FAIL="✗"
 # Counters
 COUNT_PASS=0
 COUNT_FAIL=0
+# Flag for determining whether a test script called the `runtest' function
+RUNTEST_CALLED=0
+
+AUTOMATED_TESTING=1
 
 function busctl {
   shift 4
@@ -81,8 +85,8 @@ function ip {
 
 function logger {
   # Remove standard options
-  shift 2
-  _log "-- ${@}"
+  local message="$*"
+  _log "-- ${message##* -- }"
 }
 
 function exit {
@@ -104,11 +108,42 @@ function _fail {
   ( >&2 echo -e "  ${RED}${FAIL} ${@}${RESET}" )
 }
 
+function runtest {
+  # Increment counter so that we don't double-execute if a test script calls
+  # this function.
+  : ${RUNTEST_CALLED:=0}
+  (( RUNTEST_CALLED += 1 ))
+
+  echo -e "${GREEN}- Testing ${TEST_TITLE:-a nameless test}${RESET}"
+
+  # Source, don't run, so we don't need to export and internal functions override
+  # external calls out to system commands
+  source update-systemd-resolved
+  exit_status="$?"
+  exit_message="script exited with a ${exit_status} exit status"
+
+  if [[ "$(( exit_status > 0 ))" == "${EXPECT_FAILURE:-0}" ]]; then
+      _pass "$exit_message"
+  else
+      _fail "$exit_message"
+  fi
+
+  if [[ ${TEST_BUSCTL_CALLED} -eq 0 ]]; then
+    [[ ${busctl_called} -eq 0 ]] && \
+      _pass "busctl was not called, as expected" || \
+      _fail "busctl was called, not expected"
+  fi
+
+  echo
+}
+
 echo "update-systemd-resolved Test Suite"
 echo
 
 for TEST in tests/*.sh; do
   # Set/Reset loop variables
+  RUNTEST_CALLED=0
+  EXPECT_FAILURE=0
   busctl_called=0
   # Keep this random, as we will never know the ifindex up-front
   ip_ifindex=$((RANDOM%=64))
@@ -121,23 +156,8 @@ for TEST in tests/*.sh; do
 
   # Import the test configuration
   source "${TEST}"
-  echo -e "${GREEN}- Testing ${TEST_TITLE}${RESET}"
 
-  # Source, don't run, so we don't need to export and internal functions override
-  # external calls out to system commands
-  source update-systemd-resolved
-
-  [[ ${?} -eq 0 ]] &&
-    _pass "script exited with a 0 exit status" || \
-    _fail "script exited with a ${1} exit status"
-
-  if [[ ${TEST_BUSCTL_CALLED} -eq 0 ]]; then
-    [[ ${busctl_called} -eq 0 ]] && \
-      _pass "busctl was not called, as expected" || \
-      _fail "busctl was called, not expected"
-  fi
-
-  echo
+  (( RUNTEST_CALLED > 0 )) || runtest
 done
 
 echo -e "  ${GREEN}${PASS} ${COUNT_PASS} Passed${RESET}"

--- a/tests/12_single_ipv6_dns_compact_1.sh
+++ b/tests/12_single_ipv6_dns_compact_1.sh
@@ -1,6 +1,6 @@
 script_type="up"
 dev="tun12"
-foreign_option_1="dhcp-option DNS 1234:567:89::ab:cde:f123:4567"
+foreign_option_1="dhcp-option DNS 1234:567:89:0:ab:cde:f123:4567"
 
 TEST_TITLE="Single IPv6 DNS Server (Compact) (Part 1)"
 TEST_BUSCTL_CALLED=1

--- a/tests/19_dns_invalid_ipv6.sh
+++ b/tests/19_dns_invalid_ipv6.sh
@@ -13,6 +13,7 @@ declare -A test_attrs=(
     ['single 0 shortened']='1234::567:89:ab:c:de:f'
     ['zero-run in wrong location']='1234:0:0:567:89::ab'
     ['compressed run not longest zero-run']='1234:0:0:0:567::89'
+    ['not maximally compressed']='2001:db8::0:1'
 )
 
 for test_title in "${!test_attrs[@]}"; do

--- a/tests/19_dns_invalid_ipv6.sh
+++ b/tests/19_dns_invalid_ipv6.sh
@@ -1,0 +1,22 @@
+script_type="up"
+dev="tun19"
+
+# busctl should not be called for any test in here
+TEST_BUSCTL_CALLED=0
+
+# update-systemd-resolved should exit nonzero for all tests
+EXPECT_FAILURE=1
+
+declare -A test_attrs=(
+    ["has more than one \`::'"]='1234::567::89:ab'
+    ['too long']='1234:567:89:a:b:c:d:e:f'
+    ['single 0 shortened']='1234::567:89:ab:c:de:f'
+    ['zero-run in wrong location']='1234:0:0:567:89::ab'
+    ['compressed run not longest zero-run']='1234:0:0:0:567::89'
+)
+
+for test_title in "${!test_attrs[@]}"; do
+    TEST_TITLE="DNS IPv6 address $test_title"
+    foreign_option_1="dhcp-option DNS ${test_attrs["$test_title"]}"
+    runtest
+done

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # OpenVPN helper to add DHCP information into systemd-resolved via DBus.
 # Copyright (C) 2016, Jonathan Wright <jon@than.io>
@@ -23,105 +23,325 @@
 #   up /etc/openvpn/update-systemd-resolved
 #   down /etc/openvpn/update-systemd-resolved
 
-# Abort if the environment is missing
-[[ -z ${script_type} || -z "${dev}" ]] && exit 0
-
-# Get ifindex for the interface
-IP_LINK="$(ip link show dev ${dev})"
-IF_INDEX="${IP_LINK//:*}"
-# Abort if ifindex not found
-[[ -z "${IF_INDEX}" ]] && exit 0
-
 # Define what needs to be called via DBus
 DBUS_DEST="org.freedesktop.resolve1"
 DBUS_NODE="/org/freedesktop/resolve1"
 
-# Preset values for processing
-dns_server_count=0
-dns_servers=""
-dns_domain_count=""
-dns_domains=""
+SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 
-function log() {
-  logger -t update-systemd-resolved "${@}"
+log() {
+  logger --id="$$" -t "$SCRIPT_NAME" "$@"
 }
 
-case $script_type in
-  up)
-    log "Link coming up"
-    for foreign_option in ${!foreign_option_*} ; do
-      option="${!foreign_option}"
-      [[ "${option// *}" == "dhcp-option" ]] || continue
-      setting="${option//dhcp-option }"
-      log "${setting}"
-      case "${setting// *}" in
-        DNS)
-          address="${setting//DNS }"
-          [[ -z "${address}" ]] && continue
-          dns_server_count=$((dns_server_count+1))
-          if [[ "${address}" =~ ":" ]]; then
-            log "Adding IPv6 DNS Server ${address}"
-            # Add array count and byte count
-            dns_servers="${dns_servers} 2 16"
-            declare -a fields
-            if [[ "${address}" =~ "::" ]]; then
-              declare -a split
-              count_left=0; count_right=0
-              split=(${address//::/ })
-              [[ -z "${split[1]}" ]] && \
-                split[1]="${split[0]}" && split[0]="0"
-              address="${split[0]}"
-              fields=(${split[0]//:/ }); count_left=${#fields[@]}
-              fields=(${split[1]//:/ }); count_right=${#fields[@]}
-              for null in $(seq 1 $((8-(count_left+count_right)))); do
-                address+=":0"
-              done
-              address+=":${split[1]}"
-            fi
-            fields=("${address//:/ }")
-            for field in ${fields[@]}; do
-              field_full="$(printf "%04x" "0x${field}")"
-              dns_servers="${dns_servers} $((16#${field_full:0:2})) $((16#${field_full:2:2}))"
-            done
-          else
-            log "Adding IPv4 DNS Server ${address}"
-            dns_servers="${dns_servers} 2 4 ${address//./ }"
-          fi
-          ;;
-        DOMAIN)
-          domain="${setting//DOMAIN }"
-          [[ -z "${domain}" ]] && continue
-          dns_domain_count=$((dns_domain_count+1))
-          log "Adding DNS Domain ${domain}"
-          dns_domains="${dns_domains} ${domain} false"
-          ;;
-        DOMAIN-SEARCH)
-          domain="${setting//DOMAIN-SEARCH }"
-          [[ -z "${domain}" ]] && continue
-          dns_domain_count=$((dns_domain_count+1))
-          log "Adding DNS Search Domain ${domain}"
-          dns_domains="${dns_domains} ${domain} true"
-          ;;
-      esac
-    done
+for level in emerg err warning info debug; do
+  printf -v functext -- '%s() { log -p user.%s -- "$@" ; }' "$level" "$level"
+  eval "$functext"
+done
 
-    [[ ${dns_server_count} -gt 0 ]] && \
-      log "SetLinkDNS(${IF_INDEX} ${dns_server_count}${dns_servers})" && \
-      busctl call ${DBUS_DEST} ${DBUS_NODE} ${DBUS_DEST}.Manager \
-        SetLinkDNS "ia(iay)" ${IF_INDEX} ${dns_server_count}${dns_servers}
+usage() {
+  err "${1:?${1}. }. Usage: ${SCRIPT_NAME} up|down device_name."
+}
 
-    [[ ${dns_domain_count} -gt 0 ]] && \
-      log "SetLinkDomains(${IF_INDEX} ${dns_domain_count}${dns_domains})" && \
-      busctl call ${DBUS_DEST} ${DBUS_NODE} ${DBUS_DEST}.Manager \
-        SetLinkDomains "ia(sb)" ${IF_INDEX} ${dns_domain_count}${dns_domains}
+busctl_call() {
+  # Preserve busctl's exit status
+  busctl call "$DBUS_DEST" "$DBUS_NODE" "${DBUS_DEST}.Manager" "$@" || {
+    local -i status=$?
+    emerg "\`busctl' exited with status $status"
+    return $status
+  }
+}
 
-    ;;
-  down)
-    log "Link going down"
-    busctl call ${DBUS_DEST} ${DBUS_NODE} ${DBUS_DEST}.Manager \
-      RevertLink i ${IF_INDEX}
-    ;;
+get_link_info() {
+  dev="$1"
+  shift
 
-esac
+  link=''
+  link="$(ip link show dev "$dev")" || return $?
 
-exit 0
+  echo "$dev" "${link%%:*}"
+}
+
+dhcp_settings() {
+  for foreign_option in "${!foreign_option_@}"; do
+    foreign_option_value="${!foreign_option}"
+
+    [[ "$foreign_option_value" == *dhcp-option* ]] \
+      && echo "${foreign_option_value#dhcp-option }"
+  done
+}
+
+up() {
+  local link="$1"
+  shift
+  local if_index="$1"
+  shift
+
+  info "Link \`$link' coming up"
+
+  # Preset values for processing -- will be altered in the various process_*
+  # functions.
+  local -a dns_servers=() dns_domains=()
+  local -i dns_server_count=0 dns_domain_count=0
+
+  while read -r setting; do
+    setting_type="${setting%% *}"
+    setting_value="${setting#* }"
+
+    process_setting_function="${setting_type,,}"
+    process_setting_function="process_${process_setting_function//-/_}"
+
+    if declare -f "$process_setting_function" &>/dev/null; then
+      "$process_setting_function" "$setting_value" || return $?
+    else
+      warning "Not a recognized DHCP setting: \`${setting}'"
+    fi
+  done < <(dhcp_settings)
+
+  if [[ "${#dns_servers[*]}" -gt 0 ]]; then
+    busctl_params=("$if_index" "$dns_server_count" "${dns_servers[@]}")
+    info "SetLinkDNS(${busctl_params[*]})"
+    busctl_call SetLinkDNS 'ia(iay)' "${busctl_params[@]}" || return $?
+  fi
+
+  if [[ "${#dns_domains[*]}" -gt 0 ]]; then
+    busctl_params=("$if_index" "$dns_domain_count" "${dns_domains[@]}")
+    info "SetLinkDomains(${busctl_params[*]})"
+    busctl_call SetLinkDomains 'ia(sb)' "${busctl_params[@]}" || return $?
+  fi
+}
+
+down() {
+  local link="$1"
+  shift
+  local if_index="$1"
+  shift
+
+  info "Link \`$link' going down"
+  busctl_call RevertLink i "$if_index"
+}
+
+process_dns() {
+  address="$1"
+  shift
+
+  if looks_like_ipv6 "$address"; then
+    process_dns_ipv6 "$address" || return $?
+  elif looks_like_ipv4 "$address"; then
+    process_dns_ipv4 "$address" || return $?
+  else
+    err "Not a valid IPv6 or IPv4 address: \`$address'"
+    return 1
+  fi
+}
+
+looks_like_ipv4() {
+  [[ -n "$1" ]] && {
+    local dots="${1//[^.]}"
+    (( ${#dots} == 3 ))
+  }
+}
+
+looks_like_ipv6() {
+  [[ -n "$1" ]] && {
+    local colons="${1//[^:]}"
+    (( ${#colons} >= 2 ))
+  }
+}
+
+process_dns_ipv4() {
+  local address="$1"
+  shift
+
+  info "Adding IPv4 DNS Server ${address}"
+  (( dns_server_count += 1 ))
+  dns_servers+=(2 4 ${address//./ })
+}
+
+# Enforces RFC 5952:
+#   1. Don't shorted a single 0 field to '::'
+#   2. Only longest run of zeros should be compressed
+#   3. If there are multiple longest runs, the leftmost should be compressed
+#
+# ...
+#
+# Thank goodness we don't have to handle port numbers, though :)
+parse_ipv6() {
+  local raw_address="$1"
+
+  log_invalid_ipv6() {
+    local message="\`$raw_address' is not a valid IPv6 address"
+    emerg "${message}: $*"
+  }
+
+  trap -- 'unset -f log_invalid_ipv6' RETURN
+
+  if [[ "$raw_address" == *::*::* ]]; then
+    log_invalid_ipv6 "address cannot contain more than one \`::'"
+    return 1
+  fi
+
+  local -i length=8
+  local -a raw_segments=()
+
+  IFS=$':' read -r -a raw_segments <<<"$raw_address"
+
+  local -i raw_length="${#raw_segments[@]}"
+
+  if (( raw_length > length )); then
+    log_invalid_ipv6 "expected ${length} segments, got ${raw_length}"
+    return 1
+  fi
+
+  # Store zero-runs keyed to their sizes, storing all non-zero segments prefixed
+  # with a token marking them as such.
+  local nonzero_prefix=$'!'
+  local -i zero_run_i=0 compressed_i=0
+  local -a tokenized_segments=()
+  local decimal_segment='' next_decimal_segment=''
+
+  for (( i = 0 ; i < raw_length ; i++ )); do
+    raw_segment="${raw_segments[i]}"
+
+    printf -v decimal_segment -- '%d' "0x${raw_segment:-0}"
+
+    # We're in the compressed group.  The length of this run should be
+    # enough to bring the total number of segments to 8.
+    if [[ -z "$raw_segment" ]]; then
+      (( compressed_i = zero_run_i ))
+
+      # `+ 1' because the length of the current segment is counted in
+      # `raw_length'.
+      (( tokenized_segments[zero_run_i] = ((length - raw_length) + 1) ))
+
+      # If we have an address like `::1', skip processing the next group to
+      # avoid double-counting the zero-run, and increment the number of
+      # 0-groups to add since the second empty group is counted in
+      # `raw_length'.
+      if [[ -z "${raw_segments[i + 1]}" ]]; then
+        (( i++ ))
+        (( tokenized_segments[zero_run_i]++ ))
+      fi
+
+      (( zero_run_i++ ))
+    elif (( decimal_segment == 0 )); then
+      (( tokenized_segments[zero_run_i]++ ))
+
+      # The run is over if the next segment is not 0, so increment the
+      # tracking index.
+      printf -v next_decimal_segment -- '%d' "0x${raw_segments[i + 1]}"
+
+      (( next_decimal_segment != 0 )) && (( zero_run_i++ ))
+    else
+      # Prefix the raw segment with `nonzero_prefix' to mark this as a
+      # non-zero field.
+      tokenized_segments[zero_run_i]="${nonzero_prefix}${decimal_segment}"
+      (( zero_run_i++ ))
+    fi
+  done
+
+  if [[ "$raw_address" == *::* ]]; then
+    if (( ${#tokenized_segments[*]} == length )); then
+      log_invalid_ipv6 "single \`0' fields should not be shortened"
+      return 1
+    else
+      local -i largest_run_i=0 largest_run=0
+
+      for (( i = 0 ; i < ${#tokenized_segments[@]}; i ++ )); do
+        # Skip groups that aren't zero-runs
+        [[ "${tokenized_segments[i]:0:1}" == "$nonzero_prefix" ]] && continue
+
+        if (( tokenized_segments[i] > largest_run )); then
+          (( largest_run_i = i ))
+          largest_run="${tokenized_segments[i]}"
+        fi
+      done
+
+      local -i compressed_run="${tokenized_segments[compressed_i]}"
+
+      if (( largest_run > compressed_run )); then
+        log_invalid_ipv6 "the compressed run of all-zero fields is smaller than the largest such run"
+        return 1
+      elif (( largest_run == compressed_run )) && (( largest_run_i < compressed_i )); then
+        log_invalid_ipv6 "only the leftmost largest run of all-zero fields should be compressed"
+        return 1
+      fi
+    fi
+  fi
+
+  for segment in "${tokenized_segments[@]}"; do
+    if [[ "${segment:0:1}" == "$nonzero_prefix" ]]; then
+      printf -- '%04x\n' "${segment#${nonzero_prefix}}"
+    else
+      for (( n = 0 ; n < segment ; n++ )); do
+        echo 0000
+      done
+    fi
+  done
+}
+
+process_dns_ipv6() {
+  local address="$1"
+  shift
+
+  info "Adding IPv6 DNS Server ${address}"
+
+  local -a segments=()
+  segments=($(parse_ipv6 "$address")) || return $?
+
+  # Add array count and byte count
+  dns_servers+=(2 16)
+  for segment in "${segments[@]}"; do
+    dns_servers+=("$((16#${segment:0:2}))" "$((16#${segment:2:2}))")
+  done
+
+  (( dns_server_count += 1 ))
+}
+
+process_domain() {
+  local domain="$1"
+  shift
+
+  info "Adding DNS Domain ${domain}"
+  (( dns_domain_count += 1 ))
+  dns_domains+=("${domain}" false)
+}
+
+process_domain_search() {
+  local domain="$1"
+  shift
+
+  info "Adding DNS Search Domain ${domain}"
+  (( dns_domain_count += 1 ))
+  dns_domains+=("${domain}" true)
+}
+
+main() {
+  local script_type="$1"
+  shift
+  local dev="$1"
+  shift
+
+  if [[ -z "$script_type" ]]; then
+    usage 'No script type specified'
+    return 1
+  elif [[ -z "$dev" ]]; then
+    usage 'No device name specified'
+    return 1
+  elif ! declare -f "${script_type}" &>/dev/null; then
+    usage "Invalid script type: \`${script_type}'"
+    return 1
+  else
+    if ! read -r link if_index _ < <(get_link_info "$dev"); then
+      usage "Invalid device name: \`$dev'"
+      return 1
+    fi
+
+    "$script_type" "$link" "$if_index" "$@"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]] || [[ "$AUTOMATED_TESTING" == 1 ]]; then
+  set -o nounset
+
+  main "$script_type" "$dev" "$@"
+fi

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -31,6 +31,7 @@ SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 
 log() {
   logger --id="$$" -t "$SCRIPT_NAME" "$@"
+  echo "$@"
 }
 
 for level in emerg err warning info debug; do
@@ -158,9 +159,10 @@ process_dns_ipv4() {
 }
 
 # Enforces RFC 5952:
-#   1. Don't shorted a single 0 field to '::'
+#   1. Don't shorten a single 0 field to '::'
 #   2. Only longest run of zeros should be compressed
 #   3. If there are multiple longest runs, the leftmost should be compressed
+#   4. Address must be maximally compressed, so no all-zero runs next to '::'
 #
 # ...
 #
@@ -177,6 +179,9 @@ parse_ipv6() {
 
   if [[ "$raw_address" == *::*::* ]]; then
     log_invalid_ipv6 "address cannot contain more than one \`::'"
+    return 1
+  elif [[ "$raw_address" =~ :0+:: ]] || [[ "$raw_address" =~ ::0+: ]]; then
+    log_invalid_ipv6 "address contains a 0-group adjacent to \`::' and is not maximally shortened"
     return 1
   fi
 
@@ -241,7 +246,7 @@ parse_ipv6() {
 
   if [[ "$raw_address" == *::* ]]; then
     if (( ${#tokenized_segments[*]} == length )); then
-      log_invalid_ipv6 "single \`0' fields should not be shortened"
+      log_invalid_ipv6 "single \`0' fields should not be compressed"
       return 1
     else
       local -i largest_run_i=0 largest_run=0


### PR DESCRIPTION
Did a pretty extensive restructuring of the code, too -- may have gone a bit overboard, but all tests are passing so at least there's that :).

The IPv6 validation is not foolproof -- it doesn't check for things like non-hex characters, spaces, etc.  It just enforces RFC 5952's rules about:
1. Compressing only the largest run of all-zero segments;
2. Compressing only the leftmost of the all-zero runs if there are more than one runs of equal length; and
3. Not compressing a single zero segment.

The validator routine also checks that the address contains at most eight segments.

Would love to hear feedback, and would be more than happy to make any suggested changes.  Thanks in advance!
