### PR TITLE
Improve DESTDIR support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-PREFIX := /etc/openvpn
-DESTDIR := $(PREFIX)/scripts
+PREFIX ?= /etc/openvpn/scripts
 
 SRC = update-systemd-resolved
-DEST = $(DESTDIR)/$(SRC)
+DEST = $(DESTDIR)$(PREFIX)/$(SRC)
 
 .PHONY: all install info
 


### PR DESCRIPTION
DESTDIR is now used to define the root of the folder to install to.
This allows staged installs for packaging.

PREFIX is now overridable to further aid packaging.

See: https://www.gnu.org/prep/standards/html_node/DESTDIR.html