### PR TITLE
Under debian, bash is /bin/bash and not /usr/bin/bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ before the device is closed:
 
 ```
 script-security 2
-setenv PATH /usr/bin
+setenv PATH /usr/bin:/bin
 up /etc/openvpn/update-systemd-resolved
 down /etc/openvpn/update-systemd-resolved
 down-pre


### PR DESCRIPTION
Under debian, bash is not under /usr/bin/bash which result in an error with openvpn.

Updating the documentation (README.md).

Thanks