### PR TITLE
Fix PATH locations used in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ before the device is closed:
 
 ```
 script-security 2
-setenv PATH /usr/bin:/bin
+setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 up /etc/openvpn/update-systemd-resolved
 down /etc/openvpn/update-systemd-resolved
 down-pre


### PR DESCRIPTION
The current setting was based on Arch Linux, on which this script was developed. More restrictive versions of OpenVPN settings have meant this is becoming an error. Documentation updated.

This should fully resolve #18 by utilising the full path list for all systems.