### PR TITLE
Remove the --id option from logger.

### DIFF
--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -32,7 +32,7 @@ DBUS_NODE="/org/freedesktop/resolve1"
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 
 log() {
-  logger -s --id="$$" -t "$SCRIPT_NAME" "$@"
+  logger -s -t "$SCRIPT_NAME" "$@"
 }
 
 for level in emerg err warning info debug; do


### PR DESCRIPTION
This seems to break `logger` and abort the script due to unavailable privileges which are normally dropped under `systemd`. This should resolve #25.