### PR TITLE
Support for DNS6 command

### DIFF
--- a/tests/16a_dual_ipv6_single_ipv4.sh
+++ b/tests/16a_dual_ipv6_single_ipv4.sh
@@ -1,0 +1,8 @@
+script_type="up"
+dev="tun16"
+foreign_option_1="dhcp-option DNS6 1234:567:89::ab:cdef"
+foreign_option_2="dhcp-option DNS 1.23.4.56"
+
+TEST_TITLE="Single IPv6 and Single IPv4 DNS Servers (DNS6)"
+TEST_BUSCTL_CALLED=1
+TEST_BUSCTL_DNS="2 10 16 18 52 5 103 0 137 0 0 0 0 0 0 0 171 205 239 2 4 1 23 4 56"

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -165,6 +165,10 @@ process_dns() {
   fi
 }
 
+process_dns6() {
+  process_dns $1
+}
+
 looks_like_ipv4() {
   [[ -n "$1" ]] && {
     local dots="${1//[^.]}"


### PR DESCRIPTION
Openvpn 2.4 supports new DHCP option - DNS6. This pull request adds support for it by reusing the existing code.

Ref: https://community.openvpn.net/openvpn/ticket/243