### PR TITLE
Don't rely on command parameters as they seem unstable

### DIFF
--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -390,11 +390,6 @@ process_dnssec() {
 }
 
 main() {
-  local script_type="$1"
-  shift
-  local dev="$1"
-  shift
-
   if [[ -z "$script_type" ]]; then
     usage 'No script type specified'
     return 1


### PR DESCRIPTION
Command paramter seem in flux as 2.4.6 passes different arguments than this script expected.
OpenVPN passes script_type and dev into the helper via ENV.

Fixes https://github.com/jonathanio/update-systemd-resolved/issues/54