### PR TITLE
Update update-systemd-resolved

### DIFF
--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -336,9 +336,9 @@ process_domain() {
   local domain="$1"
   shift
 
-  info "Setting DNS Domain ${domain}"
-  (( dns_domain_count = 1 ))
-  dns_domain=("${domain}" false)
+  info "Adding DNS Domain ${domain}"
+  (( dns_domain_count += 1 ))
+  dns_domain+=("${domain}" false)
 }
 
 process_adapter_domain_suffix() {


### PR DESCRIPTION
Supports openvpn servers which return multiple DNS domains.

I use this configuration at work to have a single DNS server (on the openvpn server itself), which should be used to lookup multiple different DNS domains when connected. This small change makes it work. 

Tested with systemd 241.7 + openvpn 2.4.7
