### PR TITLE
Multiple Domain Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ features.
   effectively between the environment and command-line parameters.
 - The DNS caches are now flushed when the script as made the configuration
   changes for the link (@Edu4rdSHL)
+- Change the handling of DOMAIN to support mutiple class, with a change in the
+  way the values are processed and added to systemd-resolved (@adq)
+
+### BACKWARDS INCOMPATIBILITIES
+
+- The DOMAIN option now supports multiple calls, and rather than the last
+  provided version being the primary domain for the link, the first value is the
+  primary domain, and all subsequent calls are added as the equivalent of
+  DOMAIN-SEARCH.
 
 ## 1.2.7 (2017.11.12)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ OpenVPN, either through the server, or the client, configuration:
 |--:|---|---|
 | `DNS` | `0.0.0.0`<br />`::1` | This sets the DNS servers for the link and can take any IPv4 or IPv6 address. |
 | `DNS6` | `::1` | This sets the DNS servers for the link and can take only IPv6 addresses. |
-| `DOMAIN` or `ADAPTER_DOMAIN_SUFFIX` | `example.com` | The primary domain for this host. If set multiple times, the last provided is used. Will be the primary search domain for bare hostnames. All requests for this domain as well will be routed to the `DNS` servers provided on this link. |
+| `DOMAIN` or `ADAPTER_DOMAIN_SUFFIX` | `example.com` | The primary domain for this host. If set multiple times, the first provided is used as the primary search domain for bare hostnames. Any subsequent `DOMAIN` options will be added as the equivalent of `DOMAIN-SEARCH` options. All requests for this domain as well will be routed to the `DNS` servers provided on this link. |
 | `DOMAIN-SEARCH` | `example.com` | Secondary domains which will be used to search for bare hostnames (after any `DOMAIN`, if set) and in the order provided. All requests for this domain will be routed to the `DNS` servers provided on this link. |
 | `DOMAIN-ROUTE` | `example.com` | All requests for these domains will be routed to the `DNS` servers provided on this link. They will *not* be used to search for bare hostnames, only routed. A `DOMAIN-ROUTE` option for `.` (single period) will instruct `systemd-resolved` to route the entire namespace through to the `DNS` servers configured for this connection (unless a more specifc route has been offered by another connection for a selected name/namespace). This is useful if you wish to prevent DNS leakage. |
 | `DNSSEC` | `yes`<br />`no`</br >`allow-downgrade`</br >`default` | Control of DNSSEC should be enabled (`yes`) or disabled (`no`), or `allow-downgrade` to switch off DNSSEC only if the server doesn't support it, for any queries over this link only, or use the system default (`default`). |
@@ -132,6 +132,7 @@ push "dhcp-option DNS 10.62.3.3"
 push "dhcp-option DNS6 2001:db8::a3:c15c:b56e:619a"
 push "dhcp-option DNS6 2001:db8::a3:ffec:f61c:2e06"
 push "dhcp-option DOMAIN example.office"
+push "dhcp-option DOMAIN example.lan"
 push "dhcp-option DOMAIN-SEARCH example.com"
 push "dhcp-option DOMAIN-ROUTE example.net"
 push "dhcp-option DOMAIN-ROUTE example.org"
@@ -141,9 +142,10 @@ push "dhcp-option DNSSEC yes"
 This, added to the OpenVPN server's configuration file will set two IPv4 DNS
 servers and two IPv6 and will set the primary domain for the link to be
 `example.office`. Therefore if you try to look up the bare address `mail` then
-`mail.example.office` will be attempted first. The domain `example.com` is also
-added as an additional search domain, so if `mail.example.office` fails, then
-`mail.example.com` will be tried next.
+`mail.example.office` will be attempted first. The domains `example.lan` and
+`example.com` are also added as an additional search domain, so if
+`mail.example.office` fails, then `mail.example.lan` will be tried next,
+followed by `mail.example.com`.
 
 Requests for `example.net` and `example.org` will also be routed though to the
 four DNS servers listed too, but they will *not* be appended (i.e.

--- a/tests/04b_multiple_dns_domains.sh
+++ b/tests/04b_multiple_dns_domains.sh
@@ -5,4 +5,4 @@ foreign_option_2="dhcp-option DOMAIN example.co"
 
 TEST_TITLE="Multiple DNS Domains"
 TEST_BUSCTL_CALLED=1
-TEST_BUSCTL_DOMAINS="1 example.co false"
+TEST_BUSCTL_DOMAINS="2 example.com false example.co false"

--- a/tests/05d_dns_domain_and_search_4.sh
+++ b/tests/05d_dns_domain_and_search_4.sh
@@ -7,4 +7,4 @@ foreign_option_4="dhcp-option DOMAIN-SEARCH example.net"
 
 TEST_TITLE="DNS Dual Domain and Dual Search (with Order Check)"
 TEST_BUSCTL_CALLED=1
-TEST_BUSCTL_DOMAINS="3 example.com false example.org false example.net false"
+TEST_BUSCTL_DOMAINS="4 example.co false example.org false example.com false example.net false"

--- a/tests/07b_dns_domain_search_and_route_2.sh
+++ b/tests/07b_dns_domain_search_and_route_2.sh
@@ -9,4 +9,4 @@ foreign_option_6="dhcp-option DOMAIN-ROUTE example.uk.com"
 
 TEST_TITLE="DNS Dual Domain, Dual Search, Dual Route (with Order Check)"
 TEST_BUSCTL_CALLED=1
-TEST_BUSCTL_DOMAINS="5 example.co false example.org false example.co.uk false example.net true example.uk.com true"
+TEST_BUSCTL_DOMAINS="6 example.com false example.org false example.co.uk false example.co false example.net true example.uk.com true"

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -340,9 +340,9 @@ process_domain() {
   local domain="$1"
   shift
 
-  info "Setting DNS Domain ${domain}"
-  (( dns_domain_count = 1 ))
-  dns_domain=("${domain}" false)
+  info "Adding DNS Domain ${domain}"
+  (( dns_domain_count += 1 ))
+  dns_domain+=("${domain}" false)
 }
 
 process_adapter_domain_suffix() {

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -341,8 +341,13 @@ process_domain() {
   shift
 
   info "Adding DNS Domain ${domain}"
-  (( dns_domain_count += 1 ))
-  dns_domain+=("${domain}" false)
+  if [[ $dns_domain_count -eq 1 ]]; then
+    (( dns_search_count += 1 ))
+    dns_search+=("${domain}" false)
+  else
+    (( dns_domain_count = 1 ))
+    dns_domain+=("${domain}" false)
+  fi
 }
 
 process_adapter_domain_suffix() {


### PR DESCRIPTION
Update the handling of `DOMAIN` so that it can be provided multiple times by upstream providers. Rather than the last version being the one that is used, the first is now the priority and any subsequent options with `DOMAIN` are now treated the same as `DOMAIN-SEARCH`.