### PR TITLE
Common Configuration File

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,27 @@ all: install info
 
 install:
 	@install -Dm750 $(SRC) $(DEST)
+	@install -Dm644 $(SRC).conf $(DEST).conf
 
 info:
 	@printf 'Successfully installed %s to %s.\n' $(SRC) $(DEST)
 	@echo
-	@echo 'Now would be a good time to update /etc/nsswitch.conf:'
-	@echo '  # Use systemd-resolved first, then fall back to /etc/resolv.conf'
-	@echo '  hosts: files resolve dns myhostname'
-	@echo '  # Use /etc/resolv.conf first, then fall back to systemd-resolved'
-	@echo '  hosts: files dns resolve myhostname'
+	@echo   'Now would be a good time to update /etc/nsswitch.conf:'
 	@echo
-	@echo 'You should also update your OpenVPN configuration:'
-	@printf '  setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n  script-security 2\n  up %s\n  down %s\n  down-pre' $(DEST) $(DEST)
-
+	@echo   '  # Use systemd-resolved first, then fall back to /etc/resolv.conf'
+	@echo   '  hosts: files resolve dns myhostname'
+	@echo   '  # Use /etc/resolv.conf first, then fall back to systemd-resolved'
+	@echo   '  hosts: files dns resolve myhostname'
+	@echo
+	@echo   'You should also update your OpenVPN configuration:'
+	@echo
+	@printf '  setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
+	@echo   '  script-security 2'
+	@printf '  up %s\n' $(DEST)
+	@printf '  down %s\n' $(DEST)
+	@echo   '  down-pre'
+	@echo
+	@printf 'or pass --config %s.conf\n' $(DEST)
+	@echo 'in addition to any other --config arguments to your openvpn command.'
 test:
 	@./run-tests

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ openvpn \
   --down-pre
 ```
 
+Or, you can add the following argument to the command-line arguments of
+`openvpn`, which will use the `update-systemd-resolve.conf` file instead:
+
+```bash
+openvpn \
+  --config /etc/openvpn/scripts/update-systemd-resolved.conf
+```
+
 ## Usage
 
 `update-systemd-resolved` works by processing the `dhcp-option` commands set in

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![Build Status](https://travis-ci.org/jonathanio/update-systemd-resolved.svg?branch=features%2Funit-tests)](https://travis-ci.org/jonathanio/update-systemd-resolved)
 
-This is a helper script designed to integrate OpenVPN with the `systemd-resolved`
-service via DBus instead of trying to override `/etc/resolv.conf`, or manipulate
-`systemd-networkd` configuration files.
+This is a helper script designed to integrate OpenVPN with the
+`systemd-resolved` service via DBus instead of trying to override
+`/etc/resolv.conf`, or manipulate `systemd-networkd` configuration files.
 
-Since systemd-229, the `systemd-resolved` service has an API available via
-DBus which allows directly setting the DNS configuration for a link. This script
+Since systemd-229, the `systemd-resolved` service has an API available via DBus
+which allows directly setting the DNS configuration for a link. This script
 makes use of `busctl` from systemd to send DBus messages to `systemd-resolved`
 to update the DNS for the link created by OpenVPN.
 
@@ -18,9 +18,10 @@ All are most welcome.
 
 ## Installation
 
-If you are using a distribution of Linux with access to the Arch User Repository,
-the simplest way to install is by using the
-[openvpn-update-systemd-resolved](https://aur.archlinux.org/packages/openvpn-update-systemd-resolved/)
+[aur]:https://aur.archlinux.org/packages/openvpn-update-systemd-resolved/
+
+If you are using a distribution of Linux with uses the Arch User Repository, the
+simplest way to install is by using the [openvpn-update-systemd-resolved][aur]
 AUR package as this will take care of any updates through your package manager.
 
 Alternatively, the package can be manually installed by running the following:
@@ -41,7 +42,7 @@ systemctl start systemd-resolved.service
 ```
 
 Then update your `/etc/nsswitch.conf` file to look up DNS via the `resolve`
-service (you may need to install the NSS library which connectes libnss to
+service (you may need to install the NSS library which connects libnss to
 `systemd-resolved`):
 
 ```conf
@@ -58,10 +59,11 @@ otherwise the configuration provided by this script will only work on domains
 that cannot be resolved by the currently configured DNS servers (i.e. they must
 fall back after trying the ones set by your LAN's DHCP server).
 
+[LP1685045]:https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1685045
+
 *Note*: The NSS interface for `systemd-resolved` may be deprecated and has
-already been flagged for deprecation in Ubuntu (see
-[LP#1685045](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1685045)
-for details). In this case, you should set your `nameserver` in your
+already been flagged for deprecation in Ubuntu (see [LP#1685045][LP1685045] for
+details). In this case, you should set your `nameserver` in your
 `/etc/resolv.conf` to `127.0.0.53`, which will interact with the stub resolver
 (introduced in systemd-231) giving you the improved configuration and routing
 support, without having to worry about trying to manage your `/etc/resolv.conf`
@@ -83,7 +85,7 @@ down-pre
 the `openvpn` daemon drops privileges after establishing the connection (i.e.
 when using the `user` and `group` options). This is because only the `root` user
 will have the privileges required to talk to `systemd-resolved.service` over
-DBus. The `openvpn-plugin-down-root.so` plugin does provide support for
+DBus. The `openvpn-plugin-down-root.so` plug-in does provide support for
 enabling the `down` script to be run as the `root` user, but this has been known
 to be unreliable.
 
@@ -95,7 +97,7 @@ before the device is torn down rather than implicit on the change in
 environment.
 
 Alternatively if you don't want to edit your client configuration, you can add
-the following options to your openvpn command:
+the following options to your `openvpn` command:
 
 ```bash
 openvpn \
@@ -164,7 +166,7 @@ monitor and validate the calls made by the script based on the environment
 variables available to it at run-time. Please add a test for any new features
 you may wish to add, or update any which are wrong, and test your code by
 running `./run-tests` from the root of the repository. There are no dependencies
-on `run-tests` - it runs 100% bash and doesn't call out ot any other program or
+on `run-tests` - it runs 100% bash and doesn't call out to any other program or
 language.
 
 TravisCI is enabled on this repository: Click the link at the top of this README

--- a/update-systemd-resolved.conf
+++ b/update-systemd-resolved.conf
@@ -1,0 +1,5 @@
+script-security 2
+setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+up /etc/openvpn/scripts/update-systemd-resolved
+down /etc/openvpn/scripts/update-systemd-resolved
+down-pre


### PR DESCRIPTION
Add a common configuration which means that the `update-systemd-resolved` script can be easily imported and configured with an additional `--config` argument.

Resolves #41 