### PR TITLE
Flush caches over DBUS as well rather than using systemd-resolve

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -72,6 +72,14 @@ function busctl {
               "     Expected: '${ip_ifindex} ${TEST_BUSCTL_DNSSEC}'\n" \
               "     Received: '${@}'"
       ;;
+    FlushCaches)
+      shift 1
+      [[ -z "${@}" ]] && \
+        _pass "FlushCaches was called correctly" || \
+        _fail "FlushCaches was given arguments:\n" \
+              "     Expected: '(none)'\n" \
+              "     Received: '${@}'"
+      ;;
     *)
       _fail "Unknown command called on busctl: ${1}"
       ;;

--- a/tests/01_no_updates.sh
+++ b/tests/01_no_updates.sh
@@ -3,4 +3,4 @@ script_type="up"
 dev="tun01"
 
 TEST_TITLE="No Updates"
-TEST_BUSCTL_CALLED=0
+TEST_BUSCTL_CALLED=1

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -421,7 +421,7 @@ main() {
 
     "$script_type" "$link" "$if_index" "$@" || return 1
     # Flush the DNS cache
-    systemd-resolve --flush-caches
+    busctl_call FlushCaches
   fi
 }
 


### PR DESCRIPTION
This switches to flushing the cache with a straight DBUS call as well - no reason to use systemd-resolve (or the newer resolvectl) just for that part when doing the rest of the work over DBUS.