### PR TITLE
fix: run dnssec options before domain options

### DIFF
--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -100,6 +100,17 @@ up() {
     fi
   done < <(dhcp_settings)
 
+  if [[ -n "${dns_sec}" ]]; then
+    if [[ "${dns_sec}" == "default" ]]; then
+      # We need to provide an empty string to use the default settings
+      info "SetLinkDNSSEC($if_index '')"
+      busctl_call SetLinkDNSSEC 'is' "$if_index" "" || return $?
+    else
+      info "SetLinkDNSSEC($if_index ${dns_sec})"
+      busctl_call SetLinkDNSSEC 'is' "$if_index" "${dns_sec}" || return $?
+    fi
+  fi
+
   if [[ "${#dns_servers[*]}" -gt 0 ]]; then
     busctl_params=("$if_index" "$dns_server_count" "${dns_servers[@]}")
     info "SetLinkDNS(${busctl_params[*]})"
@@ -122,17 +133,6 @@ up() {
     fi
     info "SetLinkDomains(${busctl_params[*]})"
     busctl_call SetLinkDomains 'ia(sb)' "${busctl_params[@]}" || return $?
-  fi
-
-  if [[ -n "${dns_sec}" ]]; then
-    if [[ "${dns_sec}" == "default" ]]; then
-      # We need to provide an empty string to use the default settings
-      info "SetLinkDNSSEC($if_index '')"
-      busctl_call SetLinkDNSSEC 'is' "$if_index" "" || return $?
-    else
-      info "SetLinkDNSSEC($if_index ${dns_sec})"
-      busctl_call SetLinkDNSSEC 'is' "$if_index" "${dns_sec}" || return $?
-    fi
   fi
 }
 


### PR DESCRIPTION
systemd-resolved has a bug with DNSSEC. If domains are added prior to setting or changing the DNSSEC setting, the domains use the previous setting, it also seems that it requires a restart of systemd to reset their DNSSEC settings to what they should be.

By moving the DNSSEC stanza this ensures that the DNSSEC setting is applied before any domains are added to resolved which ensures they have the appropriate DNSSEC setting.

To reproduce this you can use a DNS server that doesn't support DNSSEC and then set DOMAIN and DOMAN-ROUTE for a domain you want to resolve, without this change queries will fail, if you restart resolved they will start working.

To validate this works, restart your system, put this change in place and connect to the VPN, queries will work immediately.