### PR TITLE
Add arm64 architecture for Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # Don't need sudo access or to install anything
 arch:
     - amd64
+    - arm64
     - ppc64le
 sudo: false
 install: true


### PR DESCRIPTION
Add the arm64 architecture for testing via Travis CI.
