### PR TITLE
Update the PREFIX path in Makefile to /usr/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX ?= /etc/openvpn/scripts
+PREFIX ?= /usr/bin
 
 SRC = update-systemd-resolved
 DEST = $(DESTDIR)$(PREFIX)/$(SRC)


### PR DESCRIPTION
Following on from #95, update the PREFIX variable in the Makefile to
match the new /usr/bin path.
