### PR TITLE
Check that org.freedesktop.resolve1 is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### IMPROVEMENTS
 
+- Check that the `org.freedesktop.resolve1` endpoint is available and
+  short-circuit with an error message if not
+  ([#105](https://github.com/jonathanio/update-systemd-resolved/pull/105)).
 - Add a `print-polkit-rules` subcommand that generates a polkit rules
   specification allowing the specified users and/or groups to perform the DBus
   call necessary for `update-systemd-resolved`'s proper operation

--- a/run-tests
+++ b/run-tests
@@ -44,6 +44,22 @@ export PATH="${toplevel}${PATH:+:${PATH}}"
 unset toplevel
 
 function busctl {
+  # Short-circuit if we got "busctl status <...>".  If TEST_BUSCTL_STATUS_RC is
+  # unset or empty, assume this is the call from the "main" function in
+  # update-systemd-resolved, rather than an automated test checking the
+  # behaviour of "busctl status <...>".
+  case "${1:-}" in
+    status)
+      if [[ -n "${TEST_BUSCTL_STATUS_RC:-}" ]]; then
+        busctl_called=1
+        _log "busctl status: returning ${TEST_BUSCTL_STATUS_RC}"
+        return "$TEST_BUSCTL_STATUS_RC"
+      else
+        return 0
+      fi
+      ;;
+  esac
+
   shift 4
   _log "busctl called with: ${@}"
   # Set that busctl has been called
@@ -216,6 +232,7 @@ evaltest() {
   TEST_BUSCTL_DNS=""
   TEST_BUSCTL_DOMAINS=""
   TEST_BUSCTL_DNSSEC=""
+  TEST_BUSCTL_STATUS_RC=""
   # Keep this random, as we will never know the ifindex up-front
   ip_ifindex=$((RANDOM%=64))
   # Clear foreign_option_*

--- a/tests/23_resolve1_dbus_presence.sh
+++ b/tests/23_resolve1_dbus_presence.sh
@@ -1,0 +1,9 @@
+script_type="up"
+dev="tun23"
+
+TEST_TITLE='Error if "busctl status org.freedesktop.resolve1" fails'
+TEST_BUSCTL_CALLED=1
+
+# Mocked-up busctl function will return exit code 1 upon "busctl status <...>"
+TEST_BUSCTL_STATUS_RC=1
+EXPECT_FAILURE=1

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -63,6 +63,10 @@ usage() {
   err "${1:?${1}. }. Usage: ${SCRIPT_NAME} up|down|print-polkit-rules [<options>]."
 }
 
+busctl_status() {
+  busctl status "$DBUS_DEST"
+}
+
 busctl_call() {
   # Preserve busctl's exit status
   busctl call "$DBUS_DEST" "$DBUS_NODE" "${DBUS_DEST}.Manager" "$@" || {
@@ -271,6 +275,15 @@ with_openvpn_script_handling() {
     usage "Invalid device name: '$dev'"
     return 1
   fi
+
+  busctl_status &>/dev/null || {
+    local -i status="$?"
+    err <<ERR
+systemd-resolved DBus interface (${DBUS_DEST}) is not available.
+$SCRIPT_NAME requires systemd version 229 or above.
+ERR
+    return "$status"
+  }
 
   if ! "$func" "$link" "$if_index" "$@"; then
     err 'Unable to configure systemd-resolved.'


### PR DESCRIPTION
and short-circuit with an error message about requiring systemd >= 229 if it is unavailable.

~~Incidental changes:~~

~~1. Ensure that the test runner sources the `update-systemd-resolved` script that lives in this repository, rather than one that might live somewhere in `PATH`, and
2. Update the test runner's `logger` function to support reading messages from stdin.~~

Above-stricken items were already taken care of in another PR.