### PR TITLE
Store the executable in /usr/local/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX ?= /usr/bin
+PREFIX ?= /usr/local/bin
 
 SRC = update-systemd-resolved
 DEST = $(DESTDIR)$(PREFIX)/$(SRC)

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ before the device is closed:
 ```conf
 script-security 2
 setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-up /usr/bin/update-systemd-resolved
+up /usr/local/bin/update-systemd-resolved
 up-restart
-down /usr/bin/update-systemd-resolved
+down /usr/local/bin/update-systemd-resolved
 down-pre
 ```
 
@@ -153,8 +153,8 @@ the following options to your `openvpn` command:
 openvpn \
   --script-security 2 \
   --setenv PATH '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
-  --up /usr/bin/update-systemd-resolved --up-restart \
-  --down /usr/bin/update-systemd-resolved --down-pre
+  --up /usr/local/bin/update-systemd-resolved --up-restart \
+  --down /usr/local/bin/update-systemd-resolved --down-pre
 ```
 
 Or, you can add the following argument to the command-line arguments of
@@ -162,7 +162,7 @@ Or, you can add the following argument to the command-line arguments of
 
 ```bash
 openvpn \
-  --config /usr/bin/update-systemd-resolved.conf
+  --config /usr/local/bin/update-systemd-resolved.conf
 ```
 
 ## Usage

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -21,8 +21,8 @@
 # install, set as the 'up' and 'down' script in your OpenVPN configuration file
 # or via the command-line arguments, alongside setting the 'down-pre' option to
 # run the 'down' script before the device is closed. For example:
-#   up /usr/bin/update-systemd-resolved
-#   down /usr/bin/update-systemd-resolved
+#   up /usr/local/bin/update-systemd-resolved
+#   down /usr/local/bin/update-systemd-resolved
 #   down-pre
 
 # Define what needs to be called via DBus

--- a/update-systemd-resolved.conf
+++ b/update-systemd-resolved.conf
@@ -1,6 +1,6 @@
 script-security 2
 setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-up /usr/bin/update-systemd-resolved
+up /usr/local/bin/update-systemd-resolved
 up-restart
-down /usr/bin/update-systemd-resolved
+down /usr/local/bin/update-systemd-resolved
 down-pre


### PR DESCRIPTION
/usr/bin is not intended to be used for locally installed software.
/usr/local/bin is a more appropriate place to default to storing
locally installed scripts, as per FHS[0].

[0] https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html