### PR TITLE
Remove `emerg` log function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Flush caches with `busctl` rather than with `resolvectl --flush-caches`
   (@cmadamsgit, [#99](https://github.com/jonathanio/update-systemd-resolved/pull/99)).
 
+### BACKWARDS INCOMPATIBILITIES
+
+- `update-systemd-resolved` no longer uses the `emerg` log level with the
+  for logging with the `logger` command, so certain messages are no longer
+  broadcast to `(p|t)ty`s ([#109](https://github.com/jonathanio/update-systemd-resolved/pull/109])).
+
 ## 1.3.0 (2019.05.19)
 
 ### NOTES

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -35,7 +35,7 @@ log() {
   logger -s -t "$SCRIPT_NAME" "$@"
 }
 
-for level in emerg err warning info debug; do
+for level in err warning info debug; do
   printf -v functext -- '%s() { log -p user.%s -- "$@" ; }' "$level" "$level"
   eval "$functext"
 done
@@ -48,7 +48,7 @@ busctl_call() {
   # Preserve busctl's exit status
   busctl call "$DBUS_DEST" "$DBUS_NODE" "${DBUS_DEST}.Manager" "$@" || {
     local -i status=$?
-    emerg "'busctl' exited with status $status"
+    err "'busctl' exited with status $status"
     return $status
   }
 }
@@ -206,7 +206,7 @@ parse_ipv6() {
 
   log_invalid_ipv6() {
     local message="'$raw_address' is not a valid IPv6 address"
-    emerg "${message}: $*"
+    err "${message}: $*"
   }
 
   trap -- 'unset -f log_invalid_ipv6' RETURN
@@ -390,7 +390,7 @@ process_dnssec() {
       setting="allow-downgrade" ;;
     *)
       local message="'$option' is not a valid DNSSEC option"
-      emerg "${message}"
+      err "${message}"
       return 1 ;;
   esac
 


### PR DESCRIPTION
and use `err` in its place.  `emerg` broadcasts messages to (p|t)tys, so this change removes a source of potentially intrusive interruptions.