### PR TITLE
Use `#!/usr/bin/env bash` as the shebang in `run-tests`

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test Framework for update-systemd-resolved.
 # Copyright (C) 2016, Jonathan Wright <jon@than.io>


### PR DESCRIPTION
This replaces `#!/bin/bash`, which is less portable.