### PR TITLE
Logging updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### IMPROVEMENTS
 
+- Support logging without `/dev/log`/`logger` ([#115](https://github.com/jonathanio/update-systemd-resolved/pull/115)).
+- Avoid doubled log output in the system journal (reported by @VannTen in
+  [#81](https://github.com/jonathanio/update-systemd-resolved/issues/81),
+  fixed in [#115](https://github.com/jonathanio/update-systemd-resolved/pull/115)).
 - Improve FHS compliance by installing `update-systemd-resolved` to
   `/usr/local/bin` by default, rather than to `/usr/local/bin`
   (@bowlofeggs, [#106](https://github.com/jonathanio/update-systemd-resolved/pull/106)).

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ This script requires:
 - [iproute2](https://wiki.linuxfoundation.org/networking/iproute2) (for the
   `ip` command).
 - [systemd](https://systemd.io/) (for the `busctl` and `resolvectl` commands).
-- [util-linux](https://en.wikipedia.org/wiki/Util-linux) (for the `logger`
-  command).
 
 Optional dependencies:
 
@@ -43,6 +41,8 @@ Optional dependencies:
   [`sipcalc`](https://github.com/sii/sipcalc).  If available, these will be
   used for IP address parsing and validation;[^iphandling] otherwise
   `update-systemd-resolved` will use native Bash routines for this.
+- [util-linux](https://en.wikipedia.org/wiki/Util-linux) (for the `logger`
+  command).
 
 [^iphandling]: Required for translating numerical labels like `1.2.3.4` to the
                byte arrays recognized by [the `SetLinkDNS()` function on

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -31,22 +31,33 @@ DBUS_NODE="/org/freedesktop/resolve1"
 
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 
-if [[ -t 2 ]]; then
-  log() {
-    logger -s -t "$SCRIPT_NAME" "$@"
-  }
-else
-  # Suppress output on stderr when not attached to a (p|t)ty.
-  # https://github.com/jonathanio/update-systemd-resolved/issues/81
-  log() {
-    logger -t "$SCRIPT_NAME" "$@"
-  }
-fi
+if [[ -S /dev/log ]] && command -v logger &>/dev/null; then
+  if [[ -t 2 ]]; then
+    log() {
+      logger -s -t "$SCRIPT_NAME" "$@"
+    }
+  else
+    # Suppress output on stderr when not attached to a (p|t)ty.
+    # https://github.com/jonathanio/update-systemd-resolved/issues/81
+    log() {
+      logger -t "$SCRIPT_NAME" "$@"
+    }
+  fi
 
-for level in err warning info debug; do
-  printf -v functext -- '%s() { log -p user.%s -- "$@" ; }' "$level" "$level"
-  eval "$functext"
-done
+  for level in err warning info debug; do
+    printf -v functext -- '%s() { log -p user.%s -- "$@" ; }' "$level" "$level"
+    eval "$functext"
+  done
+else
+  log() {
+    printf 1>&2 -- '%s: %s\n' "$SCRIPT_NAME" "$*"
+  }
+
+  for level in err warning info debug; do
+    printf -v functext -- '%s() { log "%s:" "$@" ; }' "$level" "${level^^}"
+    eval "$functext"
+  done
+fi
 
 usage() {
   err "${1:?${1}. }. Usage: ${SCRIPT_NAME} up|down device_name."

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -31,9 +31,17 @@ DBUS_NODE="/org/freedesktop/resolve1"
 
 SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
 
-log() {
-  logger -s -t "$SCRIPT_NAME" "$@"
-}
+if [[ -t 2 ]]; then
+  log() {
+    logger -s -t "$SCRIPT_NAME" "$@"
+  }
+else
+  # Suppress output on stderr when not attached to a (p|t)ty.
+  # https://github.com/jonathanio/update-systemd-resolved/issues/81
+  log() {
+    logger -t "$SCRIPT_NAME" "$@"
+  }
+fi
 
 for level in err warning info debug; do
   printf -v functext -- '%s() { log -p user.%s -- "$@" ; }' "$level" "$level"

--- a/update-systemd-resolved
+++ b/update-systemd-resolved
@@ -669,7 +669,7 @@ each_ip_expansion_func() {
     # Run in subshell with `logger` defined as a NOP to avoid issuing useless
     # messages about (say) not being able to find the `python` or `sipcalc`
     # programs.
-    if (logger() { : ; }; "test_${type}_expansion_func" "$expansion_func_impl"); then
+    if (log() { : ; }; "test_${type}_expansion_func" "$expansion_func_impl"); then
       if "$cb" "$expansion_func_impl" 1; then
         return
       fi


### PR DESCRIPTION
Summary of changes:

1. When using `logger`, log to stderr (via `logger -s`) only if connected to a `(p|t)ty`.
2. Log to stderr *without* trying to use `logger` if `/dev/log` is not a socket or the `logger` command is unavailable.

Also document that `util-linux` is now optional, and fix a small issue with unwanted output (override `log`, not `logger`, when suppressing "command not found" output while probing for available IP parsing/expansion implementations).