### PR TITLE
Add NixOS module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
             apt-get -y update
             apt-get -y install python3 sipcalc
           run: ./run-tests
-  nixos:
-    name: Run NixOS system tests
+  flake:
+    name: Run Nix flake checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -44,5 +44,5 @@ jobs:
         with:
           extra_nix_config: |
             system-features = benchmark big-parallel kvm nixos-test uid-range
-      - name: run system tests
-        run: make nixos-test
+      - name: run flake checks
+        run: nix flake check -L

--- a/docs/nixos-modules.md
+++ b/docs/nixos-modules.md
@@ -1,0 +1,633 @@
+## programs\.update-systemd-resolved\.package
+
+The update-systemd-resolved package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+` pkgs.update-systemd-resolved `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers
+
+
+
+Attribute set of ` update-systemd-resolved ` configurations\.
+Intended to be included in
+` services.openvpn.servers.<name>.config ` entries\.
+
+
+
+*Type:*
+attribute set of (submodule)
+
+
+
+*Default:*
+` { } `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.config
+
+
+
+The configuration text for inclusion in
+` services.openvpn.servers.<name>.config `\.
+
+
+
+*Type:*
+strings concatenated with “\\n” *(read only)*
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.configFile
+
+
+
+A configuration file containing
+` programs.update-systemd-resolved.servers.<name>.config `
+for inclusion in ` services.openvpn.servers.<name>.config `
+via the ` config ` directive\.
+
+
+
+*Type:*
+path *(read only)*
+
+
+
+*Default:*
+` <derivation update-systemd-resolved--name-.conf> `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.includeAutomatically
+
+
+
+Whether to include the generated configuration in
+` services.openvpn.servers.<name>.config `\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.openvpnServerName
+
+
+
+` <name> ` in
+` services.openvpn.servers.<name>.config `\.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "‹name›" `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.pushSettings
+
+
+
+Whether to push ` update-system-resolved `
+settings with OpenVPN’s ` push ` directive\.
+Enable this if the target OpenVPN instance is a server;
+disable it if the target instance is a client\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings
+
+
+
+DNS-related settings for this VPN’s link\.
+
+
+
+*Type:*
+submodule
+
+
+
+*Default:*
+` { } `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.defaultRoute
+
+
+
+Whether to use the DNS servers configured for
+this link to resolve queries for domains not
+explicitly assigned to the servers on any other
+link\.
+
+See ` resolvectl(1) `'s coverage of ` default-route ` for a
+description of this feature\.
+
+
+
+*Type:*
+(one of \<null>, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` true `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dns
+
+
+
+Attribute set naming DNS servers to configure for
+this VPN’s link\.
+
+See the description of ` DNS ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+
+
+*Type:*
+attribute set of ((submodule) or non-empty string convertible to it)
+
+
+
+*Default:*
+` { } `
+
+
+
+*Example:*
+
+```
+{
+  "3.4.5.6" = { };
+  resolver-the-first = {
+    address = "1.2.3.4";
+    port = 5353;
+  };
+  resolver-the-second = "2.3.4.5";
+}
+```
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dns\.\<name>\.__toString
+
+
+
+String representation of the DNS server\.
+
+
+
+*Type:*
+function that evaluates to a(n) string *(read only)*
+
+
+
+*Default:*
+` <function> `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dns\.\<name>\.address
+
+
+
+The IPv4 or IPv6 address of the DNS server\.
+
+
+
+*Type:*
+non-empty string
+
+
+
+*Default:*
+` "‹name›" `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dns\.\<name>\.interface
+
+
+
+Network interface name or index (note that this is as
+detailed as ` resolved.conf(5) ` gets about the
+meaning of the interface component of a DNS server
+specification)\.
+
+
+
+*Type:*
+null or non-empty string
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dns\.\<name>\.port
+
+
+
+The port number of the DNS server\.
+
+
+
+*Type:*
+null or 16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dns\.\<name>\.sni
+
+
+
+Server name indication to send when using DNS-over-TLS\.
+
+
+
+*Type:*
+null or non-empty string
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dnsOverTLS
+
+
+
+Whether to enable DNS-over-TLS for this link\.
+
+See the description of ` DNSOverTLS ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+In addition to the values documented there, this option also
+accepts the value “default”, signifying that this link should use
+the global value for ` DNSOverTLS ` configured in ` resolved.conf `\.
+
+
+
+*Type:*
+(one of \<null>, “default”, “opportunistic”, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dnssec
+
+
+
+Whether to enable DNSSEC for this link\.
+
+See the description of ` DNSSEC ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+In addition to the values documented there, this option also
+accepts the value “default”, signifying that this link should use
+the global value for ` DNSSEC ` configured in ` resolved.conf `\.
+
+
+
+*Type:*
+(one of \<null>, “allow-downgrade”, “default”, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.dnssecNegativeTrustAnchors
+
+
+
+DNSSEC negative trust anchors to configure for
+this link\.  See the ` NEGATIVE TRUST ANCHORS `
+section in ` dnssec-trust-anchors.d ` for
+a description of negative trust anchors and how
+to specify them\.
+
+
+
+*Type:*
+list of non-empty string
+
+
+
+*Default:*
+` [ ] `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.domain
+
+
+
+Main domain to configure for this link\.
+
+See the description of ` Domains ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+
+
+*Type:*
+null or non-empty string
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.flushCaches
+
+
+
+Whether to flush ` systemd-resolved `’s upon
+starting the VPN\.
+
+See ` resolvectl(1) `'s coverage of ` flush-caches ` for a
+description of this feature\.
+
+
+
+*Type:*
+(one of \<null>, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.llmnr
+
+
+
+Whether to enable LLMNR for this link\.
+
+See the description of ` LLMNR ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+In addition to the values documented there, this option also
+accepts the value “default”, signifying that this link should use
+the global value for ` LLMNR ` configured in ` resolved.conf `\.
+
+
+
+*Type:*
+(one of \<null>, “default”, “resolve”, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` "default" `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.multicastDNS
+
+
+
+Whether to enable multicast DNS for this link\.
+
+See the description of ` MulticastDNS ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+In addition to the values documented there, this option also
+accepts the value “default”, signifying that this link should use
+the global value for ` MulticastDNS ` configured in ` resolved.conf `\.
+
+
+
+*Type:*
+(one of \<null>, “default”, “resolve”, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` "default" `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.resetServerFeatures
+
+
+
+Whether to reset learned server features when
+bringing up the VPN link\.
+
+See ` resolvectl(1) `'s coverage of ` reset-server-features ` for a
+description of this feature\.
+
+
+
+*Type:*
+(one of \<null>, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` true `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.resetStatistics
+
+
+
+Whether to reset the statistics counters shown in
+` resolvectl statistics ` to zero when
+bringing up the VPN link\.
+
+See ` resolvectl(1) `'s coverage of ` reset-statistics ` for a
+description of this feature\.
+
+
+
+*Type:*
+(one of \<null>, “yes”, “no”) or boolean convertible to it
+
+
+
+*Default:*
+` true `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.routeOnlyDomains
+
+
+
+List of route-only domains to configure for this
+link\.
+
+See the description of ` Domains ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+
+
+*Type:*
+list of non-empty string
+
+
+
+*Default:*
+` [ ] `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+
+
+## programs\.update-systemd-resolved\.servers\.\<name>\.settings\.searchDomains
+
+
+
+List of search domains to configure for this
+link\.
+
+See the description of ` Domains ` in ` resolved.conf(5) ` for
+the meaning of this option and its available values\.
+
+
+
+*Type:*
+list of non-empty string
+
+
+
+*Default:*
+` [ ] `
+
+*Declared by:*
+ - [nix/nixos-modules\.nix](/nix/nixos-modules.nix)
+
+

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         inputs.flake-parts.flakeModules.easyOverlay
         ./nix/checks.nix
         ./nix/devshells.nix
+        ./nix/nixos-modules.nix
         ./nix/packages.nix
       ];
     });

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -7,22 +7,23 @@
   }: {
     checks.default = config.checks.update-systemd-resolved;
 
-    checks.docs = pkgs.runCommand "update-systemd-resolved-docs-check" {
-      src = self;
-    } ''
-      current="''${src}/docs/nixos-modules.md"
-      target=${config.packages.docs}
+    checks.docs =
+      pkgs.runCommand "update-systemd-resolved-docs-check" {
+        src = self;
+      } ''
+        current="''${src}/docs/nixos-modules.md"
+        target=${config.packages.docs}
 
-      if ! [ -f "$current" ]; then
-        printf 1>&2 -- 'missing "%s"; please generate documentation with `mkoptdocs`.\n' "$current"
-        exit 1
-      elif ! ${pkgs.diffutils}/bin/cmp "$current" "$target"; then
-        printf 1>&2 -- '"%s" and "%s" differ; please generate documentation with `mkoptdocs`.\n' "$current" "$target"
-        exit 1
-      else
-        touch "$out"
-      fi
-    '';
+        if ! [ -f "$current" ]; then
+          printf 1>&2 -- 'missing "%s"; please generate documentation with `mkoptdocs`.\n' "$current"
+          exit 1
+        elif ! ${pkgs.diffutils}/bin/cmp "$current" "$target"; then
+          printf 1>&2 -- '"%s" and "%s" differ; please generate documentation with `mkoptdocs`.\n' "$current" "$target"
+          exit 1
+        else
+          touch "$out"
+        fi
+      '';
 
     checks.update-systemd-resolved = let
       # Name of the test script

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -221,6 +221,10 @@
             };
             polkitRules = mkPolkitRulesForService config.systemd.services.${serviceAttrName};
           in {
+            imports = [
+              self.nixosModules.update-systemd-resolved
+            ];
+
             networking.useNetworkd = true;
 
             services.resolved = {
@@ -258,6 +262,30 @@
               dnsutils # for "dig"
             ];
 
+            programs.update-systemd-resolved.servers.${instanceName} = {
+              includeAutomatically = true;
+
+              settings = {
+                dns.resolver = {name, ...}: {
+                  address = resolverIP;
+                  port = resolverPort;
+                  sni = name;
+                };
+
+                domain = vpnDomain;
+
+                defaultRoute = true;
+                dnsOverTLS = "yes";
+                dnssec = true;
+                dnssecNegativeTrustAnchors = [vpnDomain];
+                flushCaches = "yes";
+                llmnr = "resolve";
+                multicastDNS = "default";
+                resetServerFeatures = true;
+                resetStatistics = "yes";
+              };
+            };
+
             services.openvpn.servers.${instanceName} = {
               config = ''
                 remote server
@@ -267,23 +295,6 @@
                 ifconfig ${clientEndpoint} ${serverEndpoint}
 
                 providers legacy default
-
-                config ${perSystem.config.packages.update-systemd-resolved}/share/doc/openvpn/update-systemd-resolved.conf
-
-                dhcp-option DNS ${resolverIP}:${toString resolverPort}#resolver
-                dhcp-option DOMAIN ${vpnDomain}
-
-                dhcp-option FLUSH-CACHES yes
-                dhcp-option RESET-SERVER-FEATURES true
-                dhcp-option RESET-STATISTICS yes
-
-                dhcp-option DEFAULT-ROUTE yes
-                dhcp-option DNS-OVER-TLS yes
-                dhcp-option LLMNR resolve
-                dhcp-option MULTICAST-DNS default
-
-                dhcp-option DNSSEC true
-                dhcp-option DNSSEC-NEGATIVE-TRUST-ANCHORS ${vpnDomain}
               '';
             };
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -7,6 +7,23 @@
   }: {
     checks.default = config.checks.update-systemd-resolved;
 
+    checks.docs = pkgs.runCommand "update-systemd-resolved-docs-check" {
+      src = self;
+    } ''
+      current="''${src}/docs/nixos-modules.md"
+      target=${config.packages.docs}
+
+      if ! [ -f "$current" ]; then
+        printf 1>&2 -- 'missing "%s"; please generate documentation with `mkoptdocs`.\n' "$current"
+        exit 1
+      elif ! ${pkgs.diffutils}/bin/cmp "$current" "$target"; then
+        printf 1>&2 -- '"%s" and "%s" differ; please generate documentation with `mkoptdocs`.\n' "$current" "$target"
+        exit 1
+      else
+        touch "$out"
+      fi
+    '';
+
     checks.update-systemd-resolved = let
       # Name of the test script
       name = "update-systemd-resolved";

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -59,6 +59,27 @@
               exit 1
             '');
         }
+
+        {
+          name = "mkoptdocs";
+          category = "maintenance";
+          help = "Generate NixOS module options documentation";
+          command = ''
+            docs="$(${pkgs.nix}/bin/nix "$@" build --print-out-paths --no-link "''${PRJ_ROOT}#docs")" || exit
+
+            seen=0
+            while read -r path; do
+              seen="$((seen + 1))"
+              if [ "$seen" -gt 1 ]; then
+                printf 1>&2 -- 'error: more than one output path...\n'
+                exit 1
+              fi
+              install -Dm0644 "$path" "''${PRJ_ROOT}/docs/nixos-modules.md"
+            done <<DOCS
+            $docs
+            DOCS
+          '';
+        }
       ];
 
       devshell = {

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -1,0 +1,401 @@
+{
+  self,
+  moduleWithSystem,
+  ...
+}: {
+  flake = {config, ...}: {
+    nixosModules.default = config.nixosModules.update-systemd-resolved;
+
+    nixosModules.update-systemd-resolved =
+      moduleWithSystem
+      (
+        perSystem @ {config}: nixos @ {
+          config,
+          lib,
+          pkgs,
+          ...
+        }: let
+          inherit (lib) mkOption mkPackageOption types;
+
+          cfg = config.programs.update-systemd-resolved;
+
+          # Convert to a format systemd understands
+          bool2str = bool:
+            if bool
+            then "yes"
+            else "no";
+
+          enumOrBool = enum: types.coercedTo types.bool bool2str (types.enum ((lib.toList enum) ++ ["yes" "no"]));
+
+          mkResolvedConfDesc = name: ''
+            See the description of `${name}` in {manpage}`resolved.conf(5)` for
+            the meaning of this option and its available values.
+          '';
+
+          mkResolvedConfDescWithDefault = name: ''
+            ${mkResolvedConfDesc name}
+
+            In addition to the values documented there, this option also
+            accepts the value "default", signifying that this link should use
+            the global value for `${name}` configured in `resolved.conf`.
+          '';
+
+          mkResolvectlDesc = cmd: ''
+            See {manpage}`resolvectl(1)`'s coverage of {command}`${cmd}` for a
+            description of this feature.
+          '';
+
+          dnsModule = types.submodule ({name, ...}: {
+            options = {
+              address = mkOption {
+                type = types.nonEmptyStr;
+                default = name;
+                description = ''
+                  The IPv4 or IPv6 address of the DNS server.
+                '';
+              };
+
+              port = mkOption {
+                type = types.nullOr types.port;
+                default = null;
+                description = ''
+                  The port number of the DNS server.
+                '';
+              };
+
+              interface = mkOption {
+                type = types.nullOr types.nonEmptyStr;
+                default = null;
+                description = ''
+                  Network interface name or index (note that this is as
+                  detailed as {manpage}`resolved.conf(5)` gets about the
+                  meaning of the interface component of a DNS server
+                  specification).
+                '';
+              };
+
+              sni = mkOption {
+                type = types.nullOr types.nonEmptyStr;
+                default = null;
+                description = ''
+                  Server name indication to send when using DNS-over-TLS.
+                '';
+              };
+
+              __toString = mkOption {
+                type = types.functionTo types.str;
+                readOnly = true;
+                description = ''
+                  String representation of the DNS server.
+                '';
+                default = self: let
+                  looksLikeIPv6 = lib.hasInfix ":" self.address;
+                  hasPort = self.port != null;
+                  address =
+                    if looksLikeIPv6 && hasPort
+                    then "[${self.address}]"
+                    else self.address;
+                in
+                  lib.concatStrings ([
+                      address
+                    ]
+                    ++ lib.optional hasPort ":${toString self.port}"
+                    ++ lib.optional (self.interface != null) "%${self.interface}"
+                    ++ lib.optional (self.sni != null) "#${self.sni}");
+              };
+            };
+          });
+
+          dnsType = types.coercedTo types.nonEmptyStr (address: {inherit address;}) dnsModule;
+        in {
+          options = {
+            programs.update-systemd-resolved = {
+              package = mkPackageOption perSystem.config.packages "update-systemd-resolved" {};
+
+              servers = mkOption {
+                default = {};
+                description = ''
+                  Attribute set of `update-systemd-resolved` configurations.
+                  Intended to be included in
+                  {option}`services.openvpn.servers.<name>.config` entries.
+                '';
+                type = types.attrsOf (types.submodule ({
+                  name,
+                  config,
+                  ...
+                }: {
+                  options = {
+                    openvpnServerName = mkOption {
+                      type = types.str;
+                      default = name;
+                      description = ''
+                        `<name>` in
+                        {option}`services.openvpn.servers.<name>.config`.
+                      '';
+                    };
+
+                    includeAutomatically = mkOption {
+                      type = types.bool;
+                      default = false;
+                      description = ''
+                        Whether to include the generated configuration in
+                        {option}`services.openvpn.servers.<name>.config`.
+                      '';
+                    };
+
+                    pushSettings = mkOption {
+                      type = types.bool;
+                      default = false;
+                      description = ''
+                        Whether to push {command}`update-system-resolved`
+                        settings with OpenVPN's {command}`push` directive.
+                        Enable this if the target OpenVPN instance is a server;
+                        disable it if the target instance is a client.
+                      '';
+                    };
+
+                    config = mkOption {
+                      type = types.lines;
+                      readOnly = true;
+                      description = ''
+                        The configuration text for inclusion in
+                        {option}`services.openvpn.servers.<name>.config`.
+                      '';
+                    };
+
+                    configFile = mkOption {
+                      type = types.path;
+                      readOnly = true;
+                      default = pkgs.writeText "update-systemd-resolved-${name}.conf" config.config;
+                      description = ''
+                        A configuration file containing
+                        {option}`programs.update-systemd-resolved.servers.<name>.config`
+                        for inclusion in {option}`services.openvpn.servers.<name>.config`
+                        via the {command}`config` directive.
+                      '';
+                    };
+
+                    settings = mkOption {
+                      default = {};
+
+                      description = ''
+                        DNS-related settings for this VPN's link.
+                      '';
+
+                      type = types.submodule ({...}: {
+                        options = {
+                          # TODO DNS6
+                          dns = mkOption {
+                            type = types.attrsOf dnsType;
+                            default = {};
+                            example = {
+                              resolver-the-first = {
+                                address = "1.2.3.4";
+                                port = 5353;
+                              };
+
+                              resolver-the-second = "2.3.4.5";
+
+                              "3.4.5.6" = {};
+                            };
+                            description = ''
+                              Attribute set naming DNS servers to configure for
+                              this VPN's link.
+
+                              ${mkResolvedConfDesc "DNS"}
+                            '';
+                          };
+
+                          domain = mkOption {
+                            type = types.nullOr types.nonEmptyStr;
+                            default = null;
+                            description = ''
+                              Main domain to configure for this link.
+
+                              ${mkResolvedConfDesc "Domains"}
+                            '';
+                          };
+
+                          searchDomains = mkOption {
+                            type = types.listOf types.nonEmptyStr;
+                            default = [];
+                            description = ''
+                              List of search domains to configure for this
+                              link.
+
+                              ${mkResolvedConfDesc "Domains"}
+                            '';
+                          };
+
+                          routeOnlyDomains = mkOption {
+                            type = types.listOf types.nonEmptyStr;
+                            default = [];
+                            description = ''
+                              List of route-only domains to configure for this
+                              link.
+
+                              ${mkResolvedConfDesc "Domains"}
+                            '';
+                          };
+
+                          defaultRoute = mkOption {
+                            type = enumOrBool null;
+                            default = true;
+                            description = ''
+                              Whether to use the DNS servers configured for
+                              this link to resolve queries for domains not
+                              explicitly assigned to the servers on any other
+                              link.
+
+                              ${mkResolvectlDesc "default-route"}
+                            '';
+                          };
+
+                          dnsOverTLS = mkOption {
+                            type = enumOrBool [null "default" "opportunistic"];
+                            default = null;
+                            description = ''
+                              Whether to enable DNS-over-TLS for this link.
+
+                              ${mkResolvedConfDescWithDefault "DNSOverTLS"}
+                            '';
+                          };
+
+                          dnssec = mkOption {
+                            type = enumOrBool [null "allow-downgrade" "default"];
+                            default = null;
+                            description = ''
+                              Whether to enable DNSSEC for this link.
+
+                              ${mkResolvedConfDescWithDefault "DNSSEC"}
+                            '';
+                          };
+
+                          dnssecNegativeTrustAnchors = mkOption {
+                            type = types.listOf types.nonEmptyStr;
+                            default = [];
+                            description = ''
+                              DNSSEC negative trust anchors to configure for
+                              this link.  See the `NEGATIVE TRUST ANCHORS`
+                              section in {manpage}`dnssec-trust-anchors.d` for
+                              a description of negative trust anchors and how
+                              to specify them.
+                            '';
+                          };
+
+                          flushCaches = mkOption {
+                            type = enumOrBool null;
+                            default = null;
+                            description = ''
+                              Whether to flush `systemd-resolved`'s upon
+                              starting the VPN.
+
+                              ${mkResolvectlDesc "flush-caches"}
+                            '';
+                          };
+
+                          llmnr = mkOption {
+                            type = enumOrBool [null "default" "resolve"];
+                            default = "default";
+                            description = ''
+                              Whether to enable LLMNR for this link.
+
+                              ${mkResolvedConfDescWithDefault "LLMNR"}
+                            '';
+                          };
+
+                          multicastDNS = mkOption {
+                            type = enumOrBool [null "default" "resolve"];
+                            default = "default";
+                            description = ''
+                              Whether to enable multicast DNS for this link.
+
+                              ${mkResolvedConfDescWithDefault "MulticastDNS"}
+                            '';
+                          };
+
+                          resetServerFeatures = mkOption {
+                            type = enumOrBool null;
+                            default = true;
+                            description = ''
+                              Whether to reset learned server features when
+                              bringing up the VPN link.
+
+                              ${mkResolvectlDesc "reset-server-features"}
+                            '';
+                          };
+
+                          resetStatistics = mkOption {
+                            type = enumOrBool null;
+                            default = true;
+                            description = ''
+                              Whether to reset the statistics counters shown in
+                              {command}`resolvectl statistics` to zero when
+                              bringing up the VPN link.
+
+                              ${mkResolvectlDesc "reset-statistics"}
+                            '';
+                          };
+                        };
+                      });
+                    };
+                  };
+
+                  config = {
+                    config = let
+                      renderDHCPOption = let
+                        client = option: value: let
+                          ucOption = lib.toUpper option;
+                        in "dhcp-option ${ucOption} ${toString value}";
+
+                        server = option: value: "push \"${client option value}\"";
+                      in
+                        if config.pushSettings
+                        then server
+                        else client;
+
+                      maybeRenderDHCPOption = option: value:
+                        lib.optionalString (value != null) renderDHCPOption option value;
+
+                      renderDHCPOptionList = option:
+                        lib.concatMapStringsSep "\n" (renderDHCPOption option);
+                    in ''
+                      config ${cfg.package}/share/doc/openvpn/update-systemd-resolved.conf
+
+                      ${renderDHCPOptionList "dns" (builtins.attrValues config.settings.dns)}
+
+                      ${maybeRenderDHCPOption "domain" config.settings.domain}
+                      ${renderDHCPOptionList "domain-route" (config.settings.routeOnlyDomains)}
+                      ${renderDHCPOptionList "domain-search" (config.settings.searchDomains)}
+
+                      ${maybeRenderDHCPOption "dnssec" config.settings.dnssec}
+                      ${renderDHCPOptionList "dnssec-negative-trust-anchors" config.settings.dnssecNegativeTrustAnchors}
+
+                      ${maybeRenderDHCPOption "default-route" config.settings.defaultRoute}
+                      ${maybeRenderDHCPOption "dns-over-tls" config.settings.dnsOverTLS}
+                      ${maybeRenderDHCPOption "flush-caches" config.settings.flushCaches}
+                      ${maybeRenderDHCPOption "llmnr" config.settings.llmnr}
+                      ${maybeRenderDHCPOption "multicast-dns" config.settings.multicastDNS}
+                      ${maybeRenderDHCPOption "reset-server-features" config.settings.resetServerFeatures}
+                      ${maybeRenderDHCPOption "reset-statistics" config.settings.resetStatistics}
+                    '';
+                  };
+                }));
+              };
+            };
+          };
+
+          config = {
+            services.openvpn.servers = lib.mapAttrs' (name: value: {
+              name = value.openvpnServerName;
+              value = {
+                config = lib.mkAfter ''
+                  config ${value.configFile}
+                '';
+              };
+            }) (lib.filterAttrs (_: s: s.includeAutomatically) cfg.servers);
+          };
+        }
+      );
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,4 +1,8 @@
-{self, inputs, ...}: {
+{
+  self,
+  inputs,
+  ...
+}: {
   perSystem = {
     config,
     pkgs,
@@ -17,12 +21,12 @@
       eval = inputs.nixpkgs.lib.nixosSystem {
         inherit system;
         modules = [
-          { system.stateVersion = "23.11"; }
+          {system.stateVersion = "23.11";}
           self.nixosModules.update-systemd-resolved
         ];
       };
 
-      allDocs =  pkgs.nixosOptionsDoc {
+      allDocs = pkgs.nixosOptionsDoc {
         inherit (eval) options;
 
         # Default is currently "appendix".
@@ -41,12 +45,19 @@
             name = nixosModules;
           };
         in
-          opt: opt // {
-            visible = opt.visible && (lib.any (lib.hasPrefix ourPrefix) opt.declarations);
-            declarations = map (decl: if lib.hasPrefix ourPrefix decl then link else decl) opt.declarations;
-          };
+          opt:
+            opt
+            // {
+              visible = opt.visible && (lib.any (lib.hasPrefix ourPrefix) opt.declarations);
+              declarations = map (decl:
+                if lib.hasPrefix ourPrefix decl
+                then link
+                else decl)
+              opt.declarations;
+            };
       };
-    in allDocs.optionsCommonMark;
+    in
+      allDocs.optionsCommonMark;
 
     packages.update-systemd-resolved = pkgs.update-systemd-resolved.overrideAttrs (oldAttrs: let
       buildInputs = with pkgs; [coreutils iproute2 systemd util-linux];

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,11 +1,52 @@
-{self, ...}: {
+{self, inputs, ...}: {
   perSystem = {
     config,
     pkgs,
     lib,
+    system,
     ...
   }: {
     packages.default = config.packages.update-systemd-resolved;
+
+    packages.docs = let
+      # Use a full NixOS system rather than (say) the result of
+      # `lib.evalModules`.  This is because our NixOS module refers to
+      # `services.openvpn`, which may itself refer to any number of other NixOS
+      # options, which may themselves... etc.  Without this, then, we'd get an
+      # evaluation error generating documentation.
+      eval = inputs.nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          { system.stateVersion = "23.11"; }
+          self.nixosModules.update-systemd-resolved
+        ];
+      };
+
+      allDocs =  pkgs.nixosOptionsDoc {
+        inherit (eval) options;
+
+        # Default is currently "appendix".
+        documentType = "none";
+
+        # We only want Markdown
+        allowDocBook = false;
+        markdownByDefault = true;
+
+        # Only include our own options.
+        transformOptions = let
+          ourPrefix = "${toString self}/";
+          nixosModules = "nix/nixos-modules.nix";
+          link = {
+            url = "/${nixosModules}";
+            name = nixosModules;
+          };
+        in
+          opt: opt // {
+            visible = opt.visible && (lib.any (lib.hasPrefix ourPrefix) opt.declarations);
+            declarations = map (decl: if lib.hasPrefix ourPrefix decl then link else decl) opt.declarations;
+          };
+      };
+    in allDocs.optionsCommonMark;
 
     packages.update-systemd-resolved = pkgs.update-systemd-resolved.overrideAttrs (oldAttrs: let
       buildInputs = with pkgs; [coreutils iproute2 systemd util-linux];


### PR DESCRIPTION
This PR introduces a NixOS module for configuring [`services.openvpn.servers`](https://search.nixos.org/options?type=packages&query=services.openvpn.servers) with `update-systemd-resolved`-specific options.

Additional changes:

1. Add a devshell command (`mkoptdocs`) for generating documentation for the options exposed by this module,
2. Add a Nix flake check that these docs are up-to-date, 
3. Update the NixOS system test to use the new NixOS module, and 
4. Run all Nix flake checks as part of the GitHub Actions workflow.